### PR TITLE
Fix timeout error in the `quickstart.mdx`

### DIFF
--- a/docs/pages/sdk/getting-started/quickstart.mdx
+++ b/docs/pages/sdk/getting-started/quickstart.mdx
@@ -122,6 +122,7 @@ const main = async () => {
   const bundlerClient = kernelClient.extend(bundlerActions(entryPoint));
   await bundlerClient.waitForUserOperationReceipt({
     hash: userOpHash,
+    timeout: 1000 * 15,
   })
 
   console.log("View completed UserOp here: https://jiffyscan.xyz/userOpHash/" + userOpHash)


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/3ff95618-dfea-4a9a-a8bc-d434e200ed18)


Currently, It prints this timeout error, so I fix it